### PR TITLE
Remove unsupported SinogramMaskId option from SART_CUDA docs

### DIFF
--- a/docs/algs/SART_CUDA.rst
+++ b/docs/algs/SART_CUDA.rst
@@ -13,7 +13,6 @@ name 					type 		description
 cfg.ProjectorId 			required 	The astra_mex_projector ID of the projector.
 cfg.ProjectionDataId 			required 	The astra_mex_data2d ID of the projection data
 cfg.ReconstructionDataId 		required 	The astra_mex_data2d ID of the reconstruction data. The content of this when starting SART is used as the initial reconstruction.
-cfg.option.SinogramMaskId 		optional 	If specified, the astra_mex_data2d ID of a projection-data-sized volume to be used as a mask.
 cfg.option.ReconstructionMaskId 	optional 	If specified, the astra_mex_data2d ID of a volume-data-sized volume to be used as a mask.
 cfg.option.MinConstraint 		optional 	If specified, all values below MinConstraint will be set to MinConstraint. This can, for example, be used to enforce non-negative reconstructions.
 cfg.option.MaxConstraint 		optional 	If specified, all values above MaxConstraint will be set to MaxConstraint.


### PR DESCRIPTION
Addresses astra-toolbox/astra-toolbox#346.